### PR TITLE
Enforce alphanumeric and uppercase 'code' values

### DIFF
--- a/src/domain/request-schema/disciplinary-action-type.schema.ts
+++ b/src/domain/request-schema/disciplinary-action-type.schema.ts
@@ -10,6 +10,8 @@ export const CREATE_DISCIPLINARY_ACTION_TYPE_SCHEMA = Joi.object({
     }),
   code: Joi.string()
     .required()
+    .alphanum()
+    .uppercase()
     .trim()
     .messages({
       'string.base': 'code must be a string',
@@ -35,6 +37,8 @@ export const CREATE_DISCIPLINARY_ACTION_TYPE_SCHEMA = Joi.object({
 
 export const UPDATE_DISCIPLINARY_ACTION_TYPE_SCHEMA = Joi.object({
   code: Joi.string()
+    .alphanum()
+    .uppercase()
     .optional()
     .trim(),
   name: Joi.string()

--- a/src/domain/request-schema/grievance-type.schema.ts
+++ b/src/domain/request-schema/grievance-type.schema.ts
@@ -9,6 +9,8 @@ export const CREATE_GRIEVANCE_TYPE_SCHEMA = Joi.object({
       'number.base': 'Company Id must be a number'
     }),
   code: Joi.string()
+    .alphanum()
+    .uppercase()
     .required()
     .trim()
     .messages({
@@ -48,7 +50,10 @@ export const UPDATE_GRIEVANCE_TYPE_SCHEMA = Joi.object({
 
 export const QUERY_GRIEVANCE_TYPE_SCHEMA = Joi.object({
   companyId: Joi.number(),
-  code: Joi.string(),
+  code: Joi.string()
+    .alphanum()
+    .uppercase()
+    .trim(),
   page: Joi.number()
     .optional()
     .min(1)

--- a/src/domain/request-schema/leave-package.schema.ts
+++ b/src/domain/request-schema/leave-package.schema.ts
@@ -6,6 +6,9 @@ export const CREATE_LEAVE_PACKAGE_SCHEMA = Joi.object({
   companyId: Joi.number()
     .required(),
   code: Joi.string()
+    .alphanum()
+    .uppercase()
+    .trim()
     .required(),
   name: Joi.string()
     .required(),
@@ -36,6 +39,9 @@ export const CREATE_LEAVE_PACKAGE_SCHEMA = Joi.object({
 
 export const UPDATE_LEAVE_PACKAGE_SCHEMA = Joi.object({
   code: Joi.string()
+    .alphanum()
+    .uppercase()
+    .trim()
     .optional(),
   name: Joi.string()
     .optional(),

--- a/src/domain/request-schema/leave-type.schema.ts
+++ b/src/domain/request-schema/leave-type.schema.ts
@@ -4,6 +4,9 @@ import Joi from 'joi';
 
 export const CREATE_LEAVE_TYPE_SCHEMA = Joi.object({
   code: Joi.string()
+    .alphanum()
+    .uppercase()
+    .trim()
     .required(),
   name: Joi.string()
     .required(),
@@ -16,6 +19,9 @@ export const CREATE_LEAVE_TYPE_SCHEMA = Joi.object({
 
 export const UPDATE_LEAVE_TYPE_SCHEMA = Joi.object({
   code: Joi.string()
+    .alphanum()
+    .uppercase()
+    .trim()
     .optional(),
   name: Joi.string()
     .optional(),


### PR DESCRIPTION
increased validation on all "code" fields to check if it's alphanumeric and also convert to uppercase and then trim